### PR TITLE
Track statistics in memory

### DIFF
--- a/src/clj/foosball_score/events.clj
+++ b/src/clj/foosball_score/events.clj
@@ -30,9 +30,9 @@
 ;; from an ID card. Example ID: 18A632
 (defmethod on-msg-size (count "18A632")
   [msg]
-  (if-let [claimed-user (persist/athlete-name (persist/lookup-athlete msg))]
+  (if-let [claimed-user (persist/lookup-athlete msg)]
     claimed-user
-    msg))
+    (persist/create-athlete! msg)))
 
 ;; Anything else is not handled
 (defmethod on-msg-size :default

--- a/src/clj/foosball_score/persistence.clj
+++ b/src/clj/foosball_score/persistence.clj
@@ -27,8 +27,9 @@
 
 (defn- make-new-athlete
   "Make the structure for a new athlete"
-  []
+  [id]
   (hash-map
+    :id id                ;; unique ID
     :name nil             ;; athlete name is empty and "unclaimed" by default
     :stats                ;; Statistics
       (hash-map
@@ -36,18 +37,18 @@
         :losses 0)))      ;; athlete losses
 
 (defmacro with-name
-  [name]
-  `(assoc (make-new-athlete) :name ~name))
+  [name id]
+  `(assoc (make-new-athlete ~id) :name ~name))
 
 (def hard-coded-players
   (hash-map
-    ian   (with-name "IAN")
-    mikel (with-name "MIKE L")
-    mikes (with-name "MIKE S")
-    tim   (with-name "TIM")
-    ryan  (with-name "RYAN")
-    eric  (with-name "ERIC")
-    norb  (with-name "NORB")))
+    ian   (with-name "IAN" ian)
+    mikel (with-name "MIKE L" mikel)
+    mikes (with-name "MIKE S" mikes)
+    tim   (with-name "TIM" tim)
+    ryan  (with-name "RYAN" ryan)
+    eric  (with-name "ERIC" eric)
+    norb  (with-name "NORB" norb)))
 
 (defonce ^:private in-mem-db (atom hard-coded-players))
 
@@ -109,7 +110,7 @@
   "Create an athlete by ID id. If the ID exists, create-athlete! does nothing."
   [id]
   (when-not (lookup-athlete id)
-    (swap! in-mem-db assoc id (make-new-athlete))
+    (swap! in-mem-db assoc id (make-new-athlete id))
     (lookup-athlete id)))
 
 (defn delete-athlete!

--- a/src/clj/foosball_score/persistence.clj
+++ b/src/clj/foosball_score/persistence.clj
@@ -109,7 +109,8 @@
   "Create an athlete by ID id. If the ID exists, create-athlete! does nothing."
   [id]
   (when-not (lookup-athlete id)
-    (swap! in-mem-db assoc id (make-new-athlete))))
+    (swap! in-mem-db assoc id (make-new-athlete))
+    (lookup-athlete id)))
 
 (defn delete-athlete!
   "Remove the athlete by ID id. Does nothing if the ID does not exist."

--- a/src/clj/foosball_score/server.clj
+++ b/src/clj/foosball_score/server.clj
@@ -8,6 +8,7 @@
     [foosball-score.state :as state]
     [foosball-score.tick :as tick]
     [foosball-score.statistics :as statistics]
+    [foosball-score.persistence :as persist]
     [config.core :refer [env]]
     [org.httpkit.server :refer [run-server]])
   (:gen-class :main true))
@@ -26,8 +27,14 @@
     (if (nil? next-state) state
       (do
         (push-event! next-state)
-        (state/update-state! next-state)
-        next-state))))
+        (state/update-state! next-state)))
+    (if-let [winners (:winners next-state)]
+      (doseq [winner winners]
+        (persist/win-for! winner)))
+    (if-let [losers (:losers next-state)]
+      (doseq [loser losers]
+        (persist/loss-for! loser)))
+    next-state))
 
 (defn every-second
   "Invoked every second to sync the time across clients"

--- a/src/clj/foosball_score/server.clj
+++ b/src/clj/foosball_score/server.clj
@@ -7,6 +7,7 @@
     [foosball-score.events :as events]
     [foosball-score.state :as state]
     [foosball-score.tick :as tick]
+    [foosball-score.statistics :as statistics]
     [config.core :refer [env]]
     [org.httpkit.server :refer [run-server]])
   (:gen-class :main true))
@@ -19,7 +20,9 @@
 (defn event-state-handler
   [event]
   (let [state @state/state
-        next-state (state/event->state state event)]
+        next-state (some-> state
+                           (state/event->state event)
+                           (statistics/win-loss-stats))]
     (if (nil? next-state) state
       (do
         (push-event! next-state)

--- a/src/clj/foosball_score/statistics.clj
+++ b/src/clj/foosball_score/statistics.clj
@@ -11,7 +11,9 @@
 (defn- pronounce-winners-losers
   "Adds winners and losers keys to the state, with a vector of related user IDs"
   [state]
-  (let [ids-of (fn [team] (set (map :id (vals (-> state :teams team)))))]
+  (let [ids-of (fn [team] 
+                 (set (filter (comp not nil?)
+                   (map :id (vals (-> state :teams team))))))]
     (if-let [winner (state/who-is-winning state)]
       (-> state
           (assoc :winners (ids-of winner))

--- a/src/clj/foosball_score/statistics.clj
+++ b/src/clj/foosball_score/statistics.clj
@@ -5,15 +5,18 @@
     [foosball-score.state :as state]
     [foosball-score.util :refer [teams]]))
 
+(def ^:private anti-team
+  (into {} [teams (vec (reverse teams))]))
+
 (defn- pronounce-winners-losers
   "Adds winners and losers keys to the state, with a vector of related user IDs"
   [state]
-  (let [losing-team (into {} [teams (vec (reverse teams))])
-        ids-of (fn [team] (set (map :id (vals (-> state :teams team)))))]
+  (let [ids-of (fn [team] (set (map :id (vals (-> state :teams team)))))]
     (if-let [winner (state/who-is-winning state)]
       (-> state
           (assoc :winners (ids-of winner))
-          (assoc :losers (ids-of (losing-team winner))))
+          (assoc :losers (ids-of (anti-team winner)))
+          (assoc :winning-team winner))
     state)))
 
 (defn win-loss-stats

--- a/src/clj/foosball_score/statistics.clj
+++ b/src/clj/foosball_score/statistics.clj
@@ -1,0 +1,27 @@
+(ns foosball-score.statistics
+  "Game and player statistics module"
+  {:author "Ian McIntyre"}
+  (:require
+    [foosball-score.state :as state]
+    [foosball-score.util :refer [teams]]))
+
+(defn- pronounce-winners-losers
+  "Adds winners and losers keys to the state, with a vector of related user IDs"
+  [state]
+  (let [losing-team (into {} [teams (vec (reverse teams))])
+        ids-of (fn [team] (set (map :id (vals (-> state :teams team)))))]
+    (if-let [winner (state/who-is-winning state)]
+      (-> state
+          (assoc :winners (ids-of winner))
+          (assoc :losers (ids-of (losing-team winner))))
+    state)))
+
+(defn win-loss-stats
+  "Accepts the state, and computes relavant statistics. If the statistics should
+  be placed into the state, puts the statistics in the state. Otherwise, returns
+  the state as-is. Never returns nil."
+  [state]
+  (if (state/game-over? state)
+    (-> state
+        pronounce-winners-losers)
+    state))

--- a/src/cljs/foosball_score/players.cljs
+++ b/src/cljs/foosball_score/players.cljs
@@ -20,15 +20,20 @@
   (let [icon (if (= pos :defense) "fa fa-shield" "fa fa-bolt")]
     [:i {:class icon}]))
 
+(defn- player-display
+  "Returns a string representing the player name and w/l counts"
+  [{:keys [name stats]}]
+  (str (if (nil? name) "UNKNOWN" name) " (" (:wins stats) "-" (:losses stats) ")"))
+
 (defn- player
   "Component that shows the player position icon and name"
   [team position next-player players]
-  (let [display (if (position players) (position players) "???")
+  (let [display-name (if (position players) (player-display (position players)) "???")
         outline (if (= next-player [team position]) "dotted" nil)]
   [:div {:style {:outline outline :margin 5}}
     [:div {:style {:padding 5}}
       [position-icon position (team colors)]
-      (gstring/unescapeEntities " &middot; ") display]]))
+      (gstring/unescapeEntities " &middot; ") display-name]]))
 
 (defn- team-player-list
   "The one to two players on a team"

--- a/src/cljs/foosball_score/players.cljs
+++ b/src/cljs/foosball_score/players.cljs
@@ -22,8 +22,8 @@
 
 (defn- player-display
   "Returns a string representing the player name and w/l counts"
-  [{:keys [name stats]}]
-  (str (if (nil? name) "UNKNOWN" name) " (" (:wins stats) "-" (:losses stats) ")"))
+  [{:keys [id name stats]}]
+  (str (if (nil? name) id name) " (" (:wins stats) "-" (:losses stats) ")"))
 
 (defn- player
   "Component that shows the player position icon and name"

--- a/test/foosball_score/statistics_test.clj
+++ b/test/foosball_score/statistics_test.clj
@@ -26,7 +26,7 @@
           lossids {:gold (:black winids) :black (:gold winids)}]
       (doseq [team [:black :gold]]
         (let [input (-> test-state
-                        (assoc-in [:scores team] 1))
+                        (update-in [:scores team] inc))
               expected (-> input
                           (assoc :winners (team winids))
                           (assoc :losers (team lossids))
@@ -36,6 +36,19 @@
                           (update-in [:teams (anti-team team) :offense :stats :losses] inc)
                           (update-in [:teams (anti-team team) :defense :stats :losses] inc))]
           (is (= (statistics/win-loss-stats input) expected))))))
+
+  (testing "Does not update stats for no player"
+    (let [input (-> test-state
+                    (assoc-in [:teams :black :offense] nil)
+                    (update-in [:scores :black] inc))
+          expected (-> input
+                       (assoc :winners #{"bd"})
+                       (assoc :losers #{"go" "gd"})
+                       (assoc :winning-team :black)
+                       (update-in [:teams :black :defense :stats :wins] inc)
+                       (update-in [:teams :gold :offense :stats :losses] inc)
+                       (update-in [:teams :gold :defense :stats :losses] inc))]
+      (is (= expected (statistics/win-loss-stats input)))))
           
   (testing "Has no win / loss stats when game is tied"
     (is (= (statistics/win-loss-stats test-state) test-state)))

--- a/test/foosball_score/statistics_test.clj
+++ b/test/foosball_score/statistics_test.clj
@@ -1,0 +1,27 @@
+(ns foosball-score.statistics-test
+  "Unit tests for statistics module"
+  {:author "Ian McIntyre"}
+  (:require
+    [clojure.test :refer :all]
+    [foosball-score.state :as state]
+    [foosball-score.statistics :as statistics]))
+
+;; The game is always over...
+(defmethod state/game-over? :stats-test
+  [_]
+  true)
+
+(def test-state
+  (-> state/new-state 
+      (assoc :game-mode :stats-test)
+      (assoc-in [:teams :black] {:offense {:id "bo"} :defense {:id "bd"}})
+      (assoc-in [:teams :gold] {:offense {:id "go"} :defense {:id "gd"}})))
+
+(deftest win-loss-stats-test
+  (testing "Identifies winners and losers in separate state entities"
+    (let [input (-> test-state
+                    (assoc-in [:scores :black] 1))
+          expected (-> input
+                       (assoc :winners #{"bo" "bd"})
+                       (assoc :losers #{"go" "gd"}))]
+      (is (= (statistics/win-loss-stats input) expected)))))

--- a/test/foosball_score/statistics_test.clj
+++ b/test/foosball_score/statistics_test.clj
@@ -19,9 +19,16 @@
 
 (deftest win-loss-stats-test
   (testing "Identifies winners and losers in separate state entities"
-    (let [input (-> test-state
-                    (assoc-in [:scores :black] 1))
-          expected (-> input
-                       (assoc :winners #{"bo" "bd"})
-                       (assoc :losers #{"go" "gd"}))]
-      (is (= (statistics/win-loss-stats input) expected)))))
+    (let [winids {:gold #{"go" "gd"} :black #{"bo" "bd"}}
+          lossids {:gold (:black winids) :black (:gold winids)}]
+      (doseq [team [:black :gold]]
+        (let [input (-> test-state
+                        (assoc-in [:scores team] 1))
+              expected (-> input
+                          (assoc :winners (team winids))
+                          (assoc :losers (team lossids))
+                          (assoc :winning-team team))]
+          (is (= (statistics/win-loss-stats input) expected))))))
+          
+  (testing "Has no win / loss identies when game is tied"
+    (is (= (statistics/win-loss-stats test-state) test-state))))

--- a/test/foosball_score/statistics_test.clj
+++ b/test/foosball_score/statistics_test.clj
@@ -4,21 +4,24 @@
   (:require
     [clojure.test :refer :all]
     [foosball-score.state :as state]
-    [foosball-score.statistics :as statistics]))
+    [foosball-score.statistics :as statistics :refer [anti-team]]))
 
 ;; The game is always over...
 (defmethod state/game-over? :stats-test
   [_]
   true)
 
+(def simple-stats
+  {:wins 0 :losses 0})
+
 (def test-state
   (-> state/new-state 
       (assoc :game-mode :stats-test)
-      (assoc-in [:teams :black] {:offense {:id "bo"} :defense {:id "bd"}})
-      (assoc-in [:teams :gold] {:offense {:id "go"} :defense {:id "gd"}})))
+      (assoc-in [:teams :black] {:offense {:id "bo" :stats simple-stats} :defense {:id "bd" :stats simple-stats}})
+      (assoc-in [:teams :gold] {:offense {:id "go" :stats simple-stats} :defense {:id "gd" :stats simple-stats}})))
 
 (deftest win-loss-stats-test
-  (testing "Identifies winners and losers in separate state entities"
+  (testing "Updates winners and losers records, and identifies IDs"
     (let [winids {:gold #{"go" "gd"} :black #{"bo" "bd"}}
           lossids {:gold (:black winids) :black (:gold winids)}]
       (doseq [team [:black :gold]]
@@ -27,8 +30,17 @@
               expected (-> input
                           (assoc :winners (team winids))
                           (assoc :losers (team lossids))
-                          (assoc :winning-team team))]
+                          (assoc :winning-team team)
+                          (update-in [:teams team :offense :stats :wins] inc)
+                          (update-in [:teams team :defense :stats :wins] inc)
+                          (update-in [:teams (anti-team team) :offense :stats :losses] inc)
+                          (update-in [:teams (anti-team team) :defense :stats :losses] inc))]
           (is (= (statistics/win-loss-stats input) expected))))))
           
-  (testing "Has no win / loss identies when game is tied"
-    (is (= (statistics/win-loss-stats test-state) test-state))))
+  (testing "Has no win / loss stats when game is tied"
+    (is (= (statistics/win-loss-stats test-state) test-state)))
+    
+  (testing "Has no win / loss stats when game is not over"
+    (let [input (assoc test-state :game-mode :not-over)]
+      (defmethod state/game-over? :not-over [_] false)
+      (is (= (statistics/win-loss-stats input) input)))))


### PR DESCRIPTION
The PR connects the persistence module to games through a statistics layer. The new statistics layer updates player win / loss counts, and describes how the persistence layer is updated.

Added supporting unit tests. Note that since the persistence is in memory, redeploys of the software erase the statistics.