### PR TITLE
Add deltapatch module

### DIFF
--- a/src/clj/foosball_score/server.clj
+++ b/src/clj/foosball_score/server.clj
@@ -16,6 +16,7 @@
 
 (defmethod foosball-event :default
   [event]
+  (println event)
   (state/update-state! (patch @state/state event))
   (push-event! event))
 

--- a/src/clj/foosball_score/server.clj
+++ b/src/clj/foosball_score/server.clj
@@ -16,7 +16,6 @@
 
 (defmethod foosball-event :default
   [event]
-  (println event)
   (state/update-state! (patch @state/state event))
   (push-event! event))
 

--- a/src/clj/foosball_score/server.clj
+++ b/src/clj/foosball_score/server.clj
@@ -19,6 +19,16 @@
   (state/update-state! (patch @state/state event))
   (push-event! event))
 
+(defn- persist-using!
+  "Handles persistence of winners or losers using the provided persistence
+  method. Returns the state with the winners / losers stripped out of the state"
+  [state k fpersist]
+  (if-let [wls (k state)]
+    (do
+      (doseq [wl wls] (fpersist wl))
+      (dissoc state k))
+    state))
+
 (defn event-state-handler
   [event]
   (let [state @state/state
@@ -26,16 +36,11 @@
                            (state/event->state event)
                            (statistics/win-loss-stats))]
     (if (nil? next-state) state
-      (do
+      (let [next-state (-> next-state
+                           (persist-using! :winners persist/win-for!)
+                           (persist-using! :losers persist/loss-for!))]
         (push-event! (delta state next-state))
-        (state/update-state! next-state)))
-    (if-let [winners (:winners next-state)]
-      (doseq [winner winners]
-        (persist/win-for! winner)))
-    (if-let [losers (:losers next-state)]
-      (doseq [loser losers]
-        (persist/loss-for! loser)))
-    next-state))
+        (state/update-state! next-state)))))
 
 (defn every-second
   "Invoked every second to sync the time across clients"

--- a/src/clj/foosball_score/server.clj
+++ b/src/clj/foosball_score/server.clj
@@ -2,9 +2,10 @@
   "Server and serial startup"
   {:author "Ian McIntyre"}
   (:require 
+    [foosball-score.events :as events]
+    [foosball-score.deltapatch :refer [delta patch]]
     [foosball-score.handler :refer [app push-event! listen-for-ws foosball-event]]
     [foosball-score.serial :as serial]
-    [foosball-score.events :as events]
     [foosball-score.state :as state]
     [foosball-score.tick :as tick]
     [foosball-score.statistics :as statistics]
@@ -15,7 +16,7 @@
 
 (defmethod foosball-event :default
   [event]
-  (state/update-state! event)
+  (state/update-state! (patch @state/state event))
   (push-event! event))
 
 (defn event-state-handler
@@ -26,7 +27,7 @@
                            (statistics/win-loss-stats))]
     (if (nil? next-state) state
       (do
-        (push-event! next-state)
+        (push-event! (delta state next-state))
         (state/update-state! next-state)))
     (if-let [winners (:winners next-state)]
       (doseq [winner winners]

--- a/src/cljc/foosball_score/deltapatch.cljc
+++ b/src/cljc/foosball_score/deltapatch.cljc
@@ -7,16 +7,17 @@
 (defn delta
   "Returns the delta from from to to for keys relevant to both"
   [from to]
-  (into {}
-    (filter (fn [[k v]] (not (= (k from) v)))
-            (reduce (fn [m [k v]]
-                      (cond
-                        (map? v) (let [vs (delta (k from) v)]
-                                   (if (not (empty? vs))
-                                       (assoc m k vs)
-                                       m))
-                        :else (assoc m k v)))
-                    {} (select-keys to (keys from))))))
+  (cond
+    (nil? from) to
+    (nil? to) nil
+    :else
+      (let [ks   (set/intersection (set (keys from)) (set (keys to)))
+            dks  (filter #(not (= (% from) (% to))) ks)]
+        (reduce (fn [m k]
+                  (if (or (map? (k from)) (map? (k to)))
+                      (assoc m k (delta (k from) (k to)))
+                      (assoc m k (k to))))
+                {} dks))))
 
 (defn patch
   "Applies the delta d to the map m"

--- a/src/cljc/foosball_score/deltapatch.cljc
+++ b/src/cljc/foosball_score/deltapatch.cljc
@@ -9,4 +9,13 @@
   [from to]
   (into {}
     (filter (fn [[k v]] (not (= (k from) v)))
-            (select-keys to (keys from)))))
+            (reduce (fn [m [k v]]
+                      (cond
+                        (map? v) (assoc m k (delta (k from) v))
+                        :else (assoc m k v)))
+                    {} (select-keys to (keys from))))))
+
+(defn patch
+  "Applies the delta d to the map m"
+  [m d]
+  (merge m d))

--- a/src/cljc/foosball_score/deltapatch.cljc
+++ b/src/cljc/foosball_score/deltapatch.cljc
@@ -11,7 +11,10 @@
     (filter (fn [[k v]] (not (= (k from) v)))
             (reduce (fn [m [k v]]
                       (cond
-                        (map? v) (assoc m k (delta (k from) v))
+                        (map? v) (let [vs (delta (k from) v)]
+                                   (if (not (empty? vs))
+                                       (assoc m k vs)
+                                       m))
                         :else (assoc m k v)))
                     {} (select-keys to (keys from))))))
 

--- a/src/cljc/foosball_score/deltapatch.cljc
+++ b/src/cljc/foosball_score/deltapatch.cljc
@@ -1,5 +1,5 @@
 (ns foosball-score.deltapatch
-  "Identify deltas and patch a map by a delta"
+  "Delta and patching for maps"
   {:author "Ian McIntyre"}
   (:require
     [clojure.set :as set]))
@@ -20,5 +20,12 @@
 
 (defn patch
   "Applies the delta d to the map m"
-  [m d]
-  (merge m d))
+  [from d]
+  (reduce (fn [n [k v]]
+            (cond
+              (map? v) (let [vs (patch (k from) v)]
+                         (if (not (empty? vs))
+                             (assoc n k vs)
+                             n))
+              :else (assoc n k v)))
+          from d))

--- a/src/cljc/foosball_score/deltapatch.cljc
+++ b/src/cljc/foosball_score/deltapatch.cljc
@@ -1,0 +1,12 @@
+(ns foosball-score.deltapatch
+  "Identify deltas and patch a map by a delta"
+  {:author "Ian McIntyre"}
+  (:require
+    [clojure.set :as set]))
+
+(defn delta
+  "Returns the delta from from to to for keys relevant to both"
+  [from to]
+  (into {}
+    (filter (fn [[k v]] (not (= (k from) v)))
+            (select-keys to (keys from)))))

--- a/src/cljs/foosball_score/core.cljs
+++ b/src/cljs/foosball_score/core.cljs
@@ -44,7 +44,6 @@
 
 (defmethod socket/foosball-event :default
   [event]
-  (println (:event event))
   (state/update-state! (patch @state/state (:event event))))
 
 (defn- on-key-press!

--- a/src/cljs/foosball_score/core.cljs
+++ b/src/cljs/foosball_score/core.cljs
@@ -8,6 +8,7 @@
    [secretary.core :as secretary :include-macros true]
    [accountant.core :as accountant]
    [taoensso.sente  :as sente]
+   [foosball-score.deltapatch :refer [delta patch]]
    [foosball-score.game :as game]
    [foosball-score.clock :as clock]
    [foosball-score.keypress :refer [keypress-handler]]
@@ -16,7 +17,7 @@
    [foosball-score.socket :as socket]
    [foosball-score.players :as players]
    [foosball-score.util :refer [ws-url]]
-   [foosball-score.state :as state :refer [state]]))
+   [foosball-score.state :as state]))
 
 ;; -------------------------
 ;; Websocket setup
@@ -33,8 +34,7 @@
 
 (defn- notify-server
   [state]
-  (state/update-state! state)
-  (chsk-send! [:foosball/v0 state]))
+  (chsk-send! [:foosball/v0 (delta @state/state state)]))
 
 (defn- swap-team!
   "Accepts the state, then returns a function that will swap the team players
@@ -44,7 +44,8 @@
 
 (defmethod socket/foosball-event :default
   [event]
-  (state/update-state! (:event event)))
+  (println (:event event))
+  (state/update-state! (patch @state/state (:event event))))
 
 (defn- on-key-press!
   "Maps a character chr to a keypress handler, forwarding through the state."
@@ -87,7 +88,7 @@
 (def page (atom #'home-page))
 
 (defn current-page []
-  [:div [@page @state]])
+  [:div [@page @state/state]])
 
 (secretary/defroute "/" []
   (reset! page #'home-page))

--- a/src/cljs/foosball_score/keypress.cljs
+++ b/src/cljs/foosball_score/keypress.cljs
@@ -46,7 +46,7 @@
     (-> state (assoc :game-mode next-game-mode))))
 
 (defmethod keypress-handler \space
-  [state chr]
+  [state _]
   (state/new-game state))
 
 (defmethod keypress-handler :default

--- a/test/foosball_score/deltapatch_test.clj
+++ b/test/foosball_score/deltapatch_test.clj
@@ -46,6 +46,14 @@
     (let [from      {:foo {:bar 1 :baz 2} :qux 43}
           to        {:foo {:bar 1 :baz 2} :qux 42}
           expected  {:qux 42}]
+      (is (= expected (delta from to)))))
+      
+  (testing "shows a player sign in"
+    (let [from      {:teams {:black {:offense nil :defense nil}
+                             :gold  {:offense nil :defense nil}}}
+          addition  {:name "Ian" :id "ABC123" :stats {:wins 1 :loses 2}}
+          to        (assoc-in from [:teams :gold :offense] addition)
+          expected  {:teams {:gold {:offense addition}}}]
       (is (= expected (delta from to))))))
 
 (deftest patch-test
@@ -53,4 +61,8 @@
     (is (= {:foo 1} (patch {} {:foo 1}))))
     
   (testing "patches an existing map with its delta"
-    (is (= {:foo 3 :bar 1} (patch {:foo 1 :bar 1} {:foo 3})))))
+    (is (= {:foo 3 :bar 1} (patch {:foo 1 :bar 1} {:foo 3}))))
+    
+  (testing "patches a nested map without losing keys"
+    (is (= {:foo {:bar 1 :baz 2}}
+           (patch {:foo {:bar 1 :baz 1}} {:foo {:baz 2}})))))

--- a/test/foosball_score/deltapatch_test.clj
+++ b/test/foosball_score/deltapatch_test.clj
@@ -54,6 +54,14 @@
           addition  {:name "Ian" :id "ABC123" :stats {:wins 1 :loses 2}}
           to        (assoc-in from [:teams :gold :offense] addition)
           expected  {:teams {:gold {:offense addition}}}]
+      (is (= expected (delta from to)))))
+      
+  (testing "shows a player sign out"
+    (let [player    {:name "Ian" :id "ABC123" :stats {:wins 1 :loses 2}}
+          from      {:teams {:black {:offense player :defense nil}
+                             :gold  {:offense nil    :defense nil}}}
+          to        (assoc-in from [:teams :black :offense] nil)
+          expected  {:teams {:black {:offense nil}}}]
       (is (= expected (delta from to))))))
 
 (deftest patch-test

--- a/test/foosball_score/deltapatch_test.clj
+++ b/test/foosball_score/deltapatch_test.clj
@@ -2,7 +2,7 @@
   "Tests for deltapatch"
   {:author "Ian McIntyre"}
   (:require
-    [foosball-score.deltapatch :refer [delta]]
+    [foosball-score.deltapatch :refer [delta patch]]
     [clojure.test :refer :all]))
 
 (deftest delta-test
@@ -14,10 +14,11 @@
 
   (testing "shows no delta for the same maps"
     (let [from      {:foo 1}
+          to        from
           expected  {}]
-      (is (= expected (delta from from)))))
+      (is (= expected (delta from to)))))
       
-  (testing "shows the delta for similar keys"
+  (testing "shows the delta only for similar keys"
     (let [from      {:foo 1 :bar 2}
           to        {:foo 3 :baz 9}
           expected  {:foo 3}]
@@ -27,4 +28,23 @@
     (let [from      {:foo {:bar 2} :baz 9}
           to        {:foo {:bar 3 :quz 8} :baz 9}
           expected  {:foo {:bar 3}}]
+      (is (= expected (delta from to)))))
+
+  (testing "shows the delta in deeply nested maps"
+    (let [from      {:bang 23 :foo {:bar {:baz 99 :qux 23}}}
+          to        {:bag 23 :foo {:bar {:baz 99 :qux 24}}} ; bang => bag ignore
+          expected  {:foo {:bar {:qux 24}}}]
+      (is (= expected (delta from to)))))
+    
+  (testing "shows the delta for different collections"
+    (let [from      {:foo [1 2] :baz 99 :bar '(4 5)}
+          to        {:foo [1 3] :baz 99 :bar '(7 8)}
+          expected  {:foo [1 3] :bar '(7 8)}]
       (is (= expected (delta from to))))))
+
+(deftest patch-test
+  (testing "patches an empty map with the delta"
+    (is (= {:foo 1} (patch {} {:foo 1}))))
+    
+  (testing "patches an existing map with its delta"
+    (is (= {:foo 3 :bar 1} (patch {:foo 1 :bar 1} {:foo 3})))))

--- a/test/foosball_score/deltapatch_test.clj
+++ b/test/foosball_score/deltapatch_test.clj
@@ -1,0 +1,30 @@
+(ns foosball-score.deltapatch-test
+  "Tests for deltapatch"
+  {:author "Ian McIntyre"}
+  (:require
+    [foosball-score.deltapatch :refer [delta]]
+    [clojure.test :refer :all]))
+
+(deftest delta-test
+  (testing "shows no delta for two unique maps"
+    (let [from      {:foo 1}
+          to        {:bar 2}
+          expected  {}]
+      (is (= expected (delta from to)))))
+
+  (testing "shows no delta for the same maps"
+    (let [from      {:foo 1}
+          expected  {}]
+      (is (= expected (delta from from)))))
+      
+  (testing "shows the delta for similar keys"
+    (let [from      {:foo 1 :bar 2}
+          to        {:foo 3 :baz 9}
+          expected  {:foo 3}]
+      (is (= expected (delta from to)))))
+      
+  (testing "shows the delta in nested maps"
+    (let [from      {:foo {:bar 2} :baz 9}
+          to        {:foo {:bar 3 :quz 8} :baz 9}
+          expected  {:foo {:bar 3}}]
+      (is (= expected (delta from to))))))

--- a/test/foosball_score/deltapatch_test.clj
+++ b/test/foosball_score/deltapatch_test.clj
@@ -40,6 +40,12 @@
     (let [from      {:foo [1 2] :baz 99 :bar '(4 5)}
           to        {:foo [1 3] :baz 99 :bar '(7 8)}
           expected  {:foo [1 3] :bar '(7 8)}]
+      (is (= expected (delta from to)))))
+      
+  (testing "shows no change for similar submaps"
+    (let [from      {:foo {:bar 1 :baz 2} :qux 43}
+          to        {:foo {:bar 1 :baz 2} :qux 42}
+          expected  {:qux 42}]
       (is (= expected (delta from to))))))
 
 (deftest patch-test


### PR DESCRIPTION
The PR adds the `deltapatch` module. The module defines recursive diffing and patching for maps.

Existing Clojure function `diff` was not satisfactory for our use case, since it would also diff non-map collections (vectors, lists, etc.). Diffing of non-map collections was undesirable; it also was more fun to implement from scratch!

Deltas are sent between clients and servers. Now, for increments of time, clients receive `{time: t}` instead of the entire state. The recipient patches in the delta before updating the state.

See accompanying unit tests to see what works and what might not work.