### PR TITLE
Feature/tcp events

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,27 +20,40 @@ analytics, and a Slack integration.
 Download the latest release from GitHub. From the command line, run
 
 ```bash
-$ java -jar foosball-scoreboard.jar /dev/[your-serial-device] 115200
+$ # Connect directly to a serial device (specify device)
+$ java -jar foosball-scoreboard.jar serial /dev/[your-serial-device]
+$ # Connect to a TCP device that mimics the serial device (specify port)
+$ java -jar foosball-scoreboard.jar tcp 3667
 ```
 
-The command line arguments, in order, are the serial device and the serial
-device baud rate. The program starts a webserver and app accessible at
-`localhost:3000`. The server monitors the serial connection for foosball events,
-and updates will be pushed to all connected clients.
+The program starts a webserver and app accessible at
+`localhost:3000`. The server monitors the connection for foosball events
+and pushes updates to connected clients.
 
 ## Keyboard controls
 
 | Key                   |    Event                       |
 | --------------------- | ------------------------------ |
 |  `SPACE`              | Start a new game               |
-|  `b`                  | Swap black team                |
-|  `g`                  | Swap gold team                 |
+|  `b`                  | Swap black team members        |
+|  `g`                  | Swap gold team members         |
 |  `m`                  | Toggle game modes              |
 |  `j/k`                | Decrease/increase mode value   |
 
-## Serial events
+## Supported game modes
 
-The server will handle any serial message that is suffixed with a newline (char
+Use `m` on the keyboard to cycle through game modes:
+
+- First to a maximum score
+  - `j/k` increase / decrease max score
+- First to a maximum score, win by two points
+  - `j/k` increase / decrease max score
+- Timed mode, time counts down
+  - `j/k` increase / decrease play time
+
+## Events
+
+The server will handle any message that is suffixed with a newline (char
 `10`). The server expects the following serial events to correspond to specific
 foosball events:
 
@@ -51,7 +64,10 @@ foosball events:
 |  `"BG"`               | Black scores a goal  |
 |  `"GG"`               | Gold scores a goal   |
 
-The codes are configurable in the Clojure `foosball-score.events` namespace.
+Consider using the `serial-msg!` function from the `repl` namespace to simulate
+serial events during testing. If you're testing a TCP event server, consider using
+`netcat` to publish the same messages. The codes are configurable in the
+`foosball-score.events` namespace.
 
 A six character string is expected to correspond with a player's ID badge.
 

--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,8 @@
                   :exclusions [org.clojure/tools.reader]]
                  [com.taoensso/sente "1.11.0"]
                  [http-kit "2.2.0"]
-                 [clj-serial "2.0.4-SNAPSHOT"]]
+                 [clj-serial "2.0.4-SNAPSHOT"]
+                 [clj-tcp "1.0.1"]]
 
   :plugins [[lein-environ "1.0.2"]
             [lein-cljsbuild "1.1.5"]

--- a/project.clj
+++ b/project.clj
@@ -1,3 +1,9 @@
+;; TODO remove once the 'Insecure HTTP repository'
+;; issue dissapears in leiningen (over 2.8.1)
+(require 'cemerick.pomegranate.aether)
+(cemerick.pomegranate.aether/register-wagon-factory!
+ "http" #(org.apache.maven.wagon.providers.http.HttpWagon.))
+
 (defproject foosball-score "0.1.0-SNAPSHOT"
   :description "Demo foosball scoreboard"
   :url "https://github.com/IQ-Inc/foosball-scoreboard-demo"

--- a/src/clj/foosball_score/serial.clj
+++ b/src/clj/foosball_score/serial.clj
@@ -28,7 +28,9 @@
 
 (defn serial-message-accumulate
   "Accumulates serial bytes into a string until the newline character. The
-  function accounts for carriage returns by trimming excess whitespace."
+  function accounts for carriage returns by trimming excess whitespace.
+  
+  DO NOT USE EXPOSED FOR TESTING."
   [in-stream]
   (loop [value (.read in-stream)
          acc []]

--- a/src/clj/foosball_score/server.clj
+++ b/src/clj/foosball_score/server.clj
@@ -7,6 +7,7 @@
     [foosball-score.handler :refer [app push-event! listen-for-ws foosball-event]]
     [foosball-score.serial :as serial]
     [foosball-score.state :as state]
+    [foosball-score.tcp :as tcp]
     [foosball-score.tick :as tick]
     [foosball-score.statistics :as statistics]
     [foosball-score.persistence :as persist]
@@ -48,13 +49,21 @@
   []
   (event-state-handler :tick))
 
+(defn- io-configuration
+  "Returns a 'port listener' and 'subscriber' mechanism, depending on the
+  specified interface. intf is one of 'serial' or 'tcp'"
+  [intf arg]
+  {:pre [(or (= intf "tcp") (= intf "serial"))]}
+  (case intf
+    "tcp"    [tcp/listen-on-port tcp/add-tcp-subscriber (read-string arg)]
+    "serial" [serial/listen-on-port tcp/add-tcp-subscriber arg]
+    "unreachable due to precondition checks"))
+
 (defn -main [& args]
   (let [port (Integer/parseInt (or (env :port) "3000"))
-        ser (nth args 0)]
-    (if-let [baud (read-string (nth args 1))]
-      (serial/listen-on-port ser baud)
-      (serial/listen-on-port ser))
-    (serial/add-serial-subscriber
+        [listen-on-port add-subscriber parsed-arg] (io-configuration (nth args 0) (nth args 1))]
+    (listen-on-port parsed-arg)
+    (add-subscriber
       (events/make-event-handler!
         event-state-handler))
     (run-server app {:port port :join? false})

--- a/src/clj/foosball_score/tcp.clj
+++ b/src/clj/foosball_score/tcp.clj
@@ -1,0 +1,39 @@
+(ns foosball-score.tcp
+  "Serial-like interface, but using TCP as the underlying protocol. Presents the exact
+  same interface as the serial module. Intended for dropping-in as a serial interface
+  replacement."
+  {:author "Ian McIntyre"}
+  (:require
+    [clj-tcp.client :as tcp]
+    [clojure.core.async :as async :refer [go go-loop <! >!]]))
+
+(def ^:private subscribers
+  (atom '()))
+
+(defn add-tcp-subscriber
+  "Register a subscriber for messages over TCP. Messages will be pushed onto
+  the provided channel."
+  [chan]
+  (swap! subscribers conj chan))
+
+(defn- bytestream->string
+  [bs]
+  (apply str (butlast (slurp bs))))
+
+(defn- loop-and-read!
+  [client]
+  (go-loop []
+    (let [bs (<! (:read-ch client))
+          msg (bytestream->string bs)
+          subs @subscribers]
+      (doseq [sub subs]
+        (go (>! sub msg))))
+    (recur)))
+
+(defn listen-on-port
+  "Begin listening on the TCP port. If a second argument is provided (a drop-in for baud rate)
+  it is entirely ignored."
+  ([port baud-rate] (listen-on-port port))
+  ([port]
+    (let [client (tcp/client "localhost" port {})]
+      (loop-and-read! client))))

--- a/src/clj/foosball_score/tcp.clj
+++ b/src/clj/foosball_score/tcp.clj
@@ -16,9 +16,16 @@
   [chan]
   (swap! subscribers conj chan))
 
+(defn- remove-line-endings
+  [chars]
+  (filter #(not (#{\newline \return} %)) 
+          chars))
+
 (defn- bytestream->string
   [bs]
-  (apply str (butlast (slurp bs))))
+  (apply str (->> bs
+                  slurp
+                  remove-line-endings)))
 
 (defn- loop-and-read!
   [client]


### PR DESCRIPTION
Getting ready and testing out the re-design...

The PR adds a TCP module to the Foosball scoreboard. In order to receive table events, the scoreboard can now connect to _either_ a TCP device _or_ a serial device. The expected messages remain the same no matter the interface. The PR also updates the docs.

I tested it with `netcat` on my machine. LGTM.