### PR TITLE
Add overtime clock

### DIFF
--- a/src/cljc/foosball_score/state.cljc
+++ b/src/cljc/foosball_score/state.cljc
@@ -39,7 +39,8 @@
 
 (def new-time-state
   {:time 0 :score-times []
-   :end-time 120})
+   :end-time 120
+   :overtime 0})
 
 ;;;;;;;;;;;;
 ;; New state
@@ -204,8 +205,8 @@
 
 (defn- update-score-times
   "Adds a score time for the provided team"
-  [{:keys [status time] :as state} team]
-  (update state :score-times conj {:time time :team team}))
+  [{:keys [status time overtime] :as state} team]
+  (update state :score-times conj {:time (+ time overtime) :team team}))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Config state modifiers
@@ -259,9 +260,9 @@
 (defmethod event->state :tick
   [{:keys [status game-mode] :as state} _]
   (when (= status :playing)
-    (if (not (overtime? state))
-        (update state :time inc)
-        state)))
+    (if (overtime? state)
+        (update state :overtime inc)
+        (update state :time inc))))
 
 ;; Drop ball
 (defmethod event->state :drop

--- a/src/cljs/foosball_score/clock.cljs
+++ b/src/cljs/foosball_score/clock.cljs
@@ -55,5 +55,6 @@
   "The game clock"
   [state]
   [:div.gameclock.scoreboard {:class (game-clock-class state) :style (game-clock-style state)}
-    [:h2 (game-time-str (time-repr state))]])
+    [:h2 (game-time-str (time-repr state))]
+    [:p {:style {:font-size "0.4em"}} (game-time-str (:overtime state))]])
   

--- a/test/foosball_score/state_test.clj
+++ b/test/foosball_score/state_test.clj
@@ -239,22 +239,23 @@
     (is (nil? (state/event->state
                 (assoc-in state/new-state [:scores :black] 5) :drop))))
 
-  (testing "Game is frozen when in overtime"
+  (testing "Game increments overtime counter when in overtime"
     (let [state (-> state/new-state
                     (assoc :status :playing)
                     (assoc :game-mode :timed-ot)
                     (assoc :time (:end-time state/new-state)))]
-      (is (= state (state/event->state state :tick)))))
+      (is (= (update state :overtime inc) (state/event->state state :tick)))))
 
   (testing "Score increments from overtime"
     (let [state (-> state/new-state
                     (assoc :status :playing)
                     (assoc :game-mode :timed-ot)
+                    (assoc :overtime 5)
                     (assoc :time (:end-time state/new-state)))]
       (is (= (-> state
                  (update-in [:scores :black] inc)
                  (assoc :status :black)
-                 (update :score-times conj {:time (:end-time state/new-state) :team :black}))
+                 (update :score-times conj {:time (+ 5 (:end-time state/new-state)) :team :black}))
              (state/event->state state :black)))))
 
   (testing "Time increments when in a timed game"


### PR DESCRIPTION
The PR adds a small overtime clock. When in overtime, the clock counts up. The clock influences the final score time when in overtime.

This was @emfrick 's suggestion!