### PR TITLE
Adapt UI for small touch screen

### DIFF
--- a/resources/public/css/site.css
+++ b/resources/public/css/site.css
@@ -55,6 +55,14 @@ p, h1, h2, h3, h4, h5, h6 {
   margin-bottom: 100px;
 }
 
+@media (max-width: 800px) {
+  .scorecard {
+    font-size: 3.2em;
+    height: 1em;
+    width: 2em;
+  }
+}
+
 .scorelist {
   width: 200px;
   height: 150px;
@@ -64,6 +72,13 @@ p, h1, h2, h3, h4, h5, h6 {
   text-align: center;
 }
 
+@media (max-width: 800px) {
+  .scorelist {
+    font-size: 1em;
+    line-height: 1.3em;
+  }
+}
+
 .gameclock {
   font-family: 'DSEG7-Modern', monospace;
   color: #777;
@@ -71,11 +86,24 @@ p, h1, h2, h3, h4, h5, h6 {
   margin-bottom: 50px;
 }
 
+@media (max-width: 800px) {
+  .gameclock {
+    font-size: 2em;
+    margin-bottom: 30px;
+  }
+}
+
 .status {
   font-family: 'Inconsolata', monospace;
   color: #777;
   font-size: 1.5em;
   margin-top: 40px;
+}
+
+@media (max-width: 800px) {
+  .status {
+    font-size: 0.8em;
+  }
 }
 
 .button {
@@ -95,6 +123,13 @@ p, h1, h2, h3, h4, h5, h6 {
   justify-content: space-around;
   font-size: 2em;
   margin-top: 50px;
+}
+
+@media (max-width: 800px) {
+  .playerlist {
+    font-size: 1em;
+    margin-top: 25px;
+  }
 }
 
 .player {

--- a/src/cljs/foosball_score/click.cljs
+++ b/src/cljs/foosball_score/click.cljs
@@ -1,0 +1,27 @@
+(ns foosball-score.click
+  "Click handlers for buttons and clickable UI elements
+  
+  The click handlers are defined in terms of keypress handlers."
+  {:author "Ian McIntyre"}
+  (:require
+    [foosball-score.keypress :refer [keypress-handler]]))
+
+(defn change-mode
+  "Change the game mode"
+  [state]
+  (keypress-handler state \m))
+
+(defn increase-setting
+  "Increase the game mode setting (score, time, etc)"
+  [state]
+  (keypress-handler state \k))
+
+(defn decrease-setting
+  "Decrease the game mode setting (score, time, etc)"
+  [state]
+  (keypress-handler state \j))
+
+(defn new-game
+  "Start a new game"
+  [state]
+  (keypress-handler state \space))

--- a/src/cljs/foosball_score/clock.cljs
+++ b/src/cljs/foosball_score/clock.cljs
@@ -53,8 +53,8 @@
 ;; Components
 (defn game-clock
   "The game clock"
-  [state]
-  [:div.gameclock.scoreboard {:class (game-clock-class state) :style (game-clock-style state)}
+  [state on-click]
+  [:div.gameclock.scoreboard {:class (game-clock-class state) :style (game-clock-style state) :on-click on-click}
     [:h2 (game-time-str (time-repr state))]
     [:p {:style {:font-size "0.4em"}} (game-time-str (:overtime state))]])
   

--- a/src/cljs/foosball_score/core.cljs
+++ b/src/cljs/foosball_score/core.cljs
@@ -11,6 +11,7 @@
    [foosball-score.colors :as colors]
    [foosball-score.deltapatch :refer [delta patch]]
    [foosball-score.game :as game]
+   [foosball-score.click :as click]
    [foosball-score.clock :as clock]
    [foosball-score.keypress :refer [keypress-handler]]
    [foosball-score.modes :as modes]
@@ -55,6 +56,12 @@
                                         (.-charCode chr)))]
     (notify-server handled)))
 
+(defn- mode-click-handlers
+  [state]
+  {:up   #(notify-server (click/increase-setting state))
+   :down #(notify-server (click/decrease-setting state))
+   :mode #(notify-server (click/change-mode state))})
+
 ;; -------------------------
 ;; Main UI manipulation
 (defonce flash (atom false))
@@ -76,8 +83,8 @@
 (defn home-page [state]
   [:div {:tab-index "1" :style (flash-effect state @flash)
          :on-key-press (partial on-key-press! state)}
-   [modes/game-modes state]
-   [clock/game-clock state]
+   [modes/game-modes state (mode-click-handlers state)]
+   [clock/game-clock state #(notify-server (click/new-game state))]
    [game/scoreboard (game/state-depends state) :black :gold]
    [status/status-msg state]
    [players/player-list (players/state-depends state) (swap-team! state)]])

--- a/src/cljs/foosball_score/modes.cljs
+++ b/src/cljs/foosball_score/modes.cljs
@@ -33,8 +33,9 @@
 
 (defn- right-mode-display
   "Show the game mode"
-  [game-mode max-score]
-  [:div ((mode->str game-mode) max-score)])
+  [game-mode max-score on-click]
+  [:div {:on-click on-click}
+    ((mode->str game-mode) max-score)])
 
 (defn- game-mode-style
   "Returns a style depending on the state"
@@ -43,7 +44,9 @@
     {:style {:background-color colors/overtime-accent}}))
 
 (defn game-modes
-  [{:keys [game-mode end-time] {:keys [max-score]} :scores :as state}]
+  [{:keys [game-mode end-time] {:keys [max-score]} :scores :as state} {:keys [mode up down]}]
   [:div.game-modes (game-mode-style state)
+    [:div {:on-click down} "-"]
     [left-mode-display game-mode max-score end-time]
-    [right-mode-display game-mode max-score]])
+    [:div {:on-click up} "+"]
+    [right-mode-display game-mode max-score mode]])


### PR DESCRIPTION
The PR adapts the UI to work on 800x480 screens. We add touch elements to behave like keyboard presses:

- press the game mode to cycle game modes
- press the - / + buttons to decrease / increase game mode setting
- press the clock to start a new game
- press the arrow cycle to swap player positions