### PR TITLE
Add disconnect error handling and reconnect

### DIFF
--- a/resources/public/css/site.css
+++ b/resources/public/css/site.css
@@ -167,6 +167,7 @@ p, h1, h2, h3, h4, h5, h6 {
 
 .ws-error {
   font-family: 'Montserrat', sans-serif;
+  margin-top: 100px;
   margin-left: 100px;
   margin-right: 100px;
   font-size: 1.5em;

--- a/resources/public/css/site.css
+++ b/resources/public/css/site.css
@@ -1,5 +1,6 @@
 @import url('https://fonts.googleapis.com/css?family=Inconsolata');
 @import url('https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css');
+@import url('https://fonts.googleapis.com/css?family=Montserrat');
 
 .body-container {
   font-family: 'Helvetica Neue', Verdana, Helvetica, Arial, monospace;
@@ -162,4 +163,11 @@ p, h1, h2, h3, h4, h5, h6 {
   to {
     visibility: hidden;
   }
+}
+
+.ws-error {
+  font-family: 'Montserrat', sans-serif;
+  margin-left: 100px;
+  margin-right: 100px;
+  font-size: 1.5em;
 }

--- a/resources/public/css/site.css
+++ b/resources/public/css/site.css
@@ -103,7 +103,7 @@ p, h1, h2, h3, h4, h5, h6 {
 
 @media (max-width: 800px) {
   .status {
-    font-size: 0.8em;
+    font-size: 1em;
   }
 }
 

--- a/src/clj/foosball_score/handler.clj
+++ b/src/clj/foosball_score/handler.clj
@@ -70,11 +70,11 @@
 
 (defmulti foosball-event
   "Handle foosball-specific events"
-  :event)
+  (fn [event _] (:event event)))
 
 (defmethod websocket-event :foosball/v0
   [event]
-  (foosball-event (get-in event [:event 1])))
+  (foosball-event (get-in event [:event 1]) (:?reply-fn event)))
 
 (defmethod websocket-event :default
   [event]

--- a/src/clj/foosball_score/handler.clj
+++ b/src/clj/foosball_score/handler.clj
@@ -45,6 +45,7 @@
 
 (defroutes routes
   (GET "/" [] (loading-page))
+  (GET "/err" [] (loading-page))
   (GET  ws-url req (ring-ajax-get-or-ws-handshake req))
   (POST ws-url req (ring-ajax-post                req))
   (resources "/")

--- a/src/clj/foosball_score/server.clj
+++ b/src/clj/foosball_score/server.clj
@@ -16,9 +16,14 @@
   (:gen-class :main true))
 
 (defmethod foosball-event :default
-  [event]
+  [event _]
   (state/update-state! (patch @state/state event))
   (push-event! event))
+
+(defmethod foosball-event :reset
+  [event ?reply-fn]
+  (when ?reply-fn
+    (?reply-fn @state/state)))
 
 (defn- persist-using!
   "Handles persistence of winners or losers using the provided persistence

--- a/src/cljs/foosball_score/core.cljs
+++ b/src/cljs/foosball_score/core.cljs
@@ -89,16 +89,25 @@
    [status/status-msg state]
    [players/player-list (players/state-depends state) (swap-team! state)]])
 
+(defn error-page [_]
+  [:div {:class "ws-error"}
+    [:h1 ":("]
+    [:div "Your Foosball table ran into a problem and needs to restart. We're just collecting some error info,
+    and then we'll restart for you."]])
+
 ;; -------------------------
 ;; Routes
 
-(def page (atom #'home-page))
+(def page (atom #'error-page))
 
 (defn current-page []
   [:div [@page @state/state]])
 
 (secretary/defroute "/" []
   (reset! page #'home-page))
+
+(secretary/defroute "/err" []
+  (reset! page #'error-page))
 
 ;; -------------------------
 ;; Initialize app

--- a/src/cljs/foosball_score/core.cljs
+++ b/src/cljs/foosball_score/core.cljs
@@ -38,6 +38,11 @@
   [state]
   (chsk-send! [:foosball/v0 (delta @state/state state)]))
 
+(defn- reset-state!
+  []
+  (chsk-send! [:foosball/v0 {:event :reset}] 750
+    (fn [state] (state/update-state! state))))
+
 (defn- swap-team!
   "Accepts the state, then returns a function that will swap the team players
   based on that state"
@@ -115,7 +120,7 @@
 (defn- ws-connection-callback
   [_ _ _ connected?]
   (if connected?
-    (secretary/dispatch! "/")
+    (do (secretary/dispatch! "/") (reset-state!))
     (secretary/dispatch! "/err")))
 
 (defn mount-root []

--- a/src/cljs/foosball_score/core.cljs
+++ b/src/cljs/foosball_score/core.cljs
@@ -98,7 +98,7 @@
 ;; -------------------------
 ;; Routes
 
-(def page (atom #'error-page))
+(def page (atom #'home-page))
 
 (defn current-page []
   [:div [@page @state/state]])
@@ -112,10 +112,17 @@
 ;; -------------------------
 ;; Initialize app
 
+(defn- ws-connection-callback
+  [_ _ _ connected?]
+  (if connected?
+    (secretary/dispatch! "/")
+    (secretary/dispatch! "/err")))
+
 (defn mount-root []
   (do
-    (reagent/render [current-page] (.getElementById js/document "app")))
-  (sente/start-client-chsk-router! ch-chsk socket/websocket-event))
+    (reagent/render [current-page] (.getElementById js/document "app"))
+    (sente/start-client-chsk-router! ch-chsk socket/websocket-event)
+    (add-watch socket/websocket-connected? :wserr ws-connection-callback)))
 
 (defn init! []
   (accountant/configure-navigation!

--- a/src/cljs/foosball_score/game.cljs
+++ b/src/cljs/foosball_score/game.cljs
@@ -34,11 +34,11 @@
                         (drop (- total 9) all-score-times)
                         all-score-times)]
     [:div.scorelist
-      (for [item score-times] ^{:key item}
+      (for [item score-times]
         (let [time (game-time-str (item :time))
               team (item :team)
               color (team colors)]
-          [:div {:style {:color color}} time]))]))
+          ^{:key (str time team color)} [:div {:style {:color color}} time]))]))
 
 (defn scoreboard-content
   "A team's scoreboard content"

--- a/src/cljs/foosball_score/socket.cljs
+++ b/src/cljs/foosball_score/socket.cljs
@@ -2,6 +2,25 @@
   "Socket input handling from the server"
   {:author "Ian McIntyre"})
 
+(defonce websocket-connected? (atom false))
+
+;; --------------------------------
+;; Websocket configuration handling
+(defmulti websocket-cfg
+  (fn [payload] (get-in payload [:event 0])))
+
+(defmethod websocket-cfg :chsk/state
+  [payload]
+  (let [[last now] (get-in payload [:event 1])
+        connected? (:open? now)]
+    (compare-and-set! websocket-connected? (not connected?) connected?)))
+
+(defmethod websocket-cfg :default
+  [_]
+  nil)
+
+;; --------------------------------
+
 (defn- foosball-version-tag
   [payload]
   (get-in payload [:?data 0]))
@@ -18,4 +37,4 @@
 
 (defmethod websocket-event :default
   [event]
-  nil)
+  (websocket-cfg event))


### PR DESCRIPTION
The PR shows an error message on websocket disconnect. When the server restarts and the websocket reconnects, the client will display the scoreboard.

The PR also establishes the client's state with the server on the first connection, a missing feature up until this point. New clients that connect to an already-active game will immediately receive the new state.