### PR TITLE
Add Slack channel integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ $ # Connect directly to a serial device (specify device)
 $ java -jar foosball-scoreboard.jar serial /dev/[your-serial-device]
 $ # Connect to a TCP device that mimics the serial device (specify port)
 $ java -jar foosball-scoreboard.jar tcp 3667
+$ # Set a Slack incoming webhook channel
+$ java -DSLACK="https://hooks.slack.com/services/YOUR_INCOMING_WEBHOOK" -jar foosball-scoreboard.jar tcp 3667
 ```
 
 The program starts a webserver and app accessible at

--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,8 @@
                  [com.taoensso/sente "1.11.0"]
                  [http-kit "2.2.0"]
                  [clj-serial "2.0.4-SNAPSHOT"]
-                 [clj-tcp "1.0.1"]]
+                 [clj-tcp "1.0.1"]
+                 [clj-http "3.8.0"]]
 
   :plugins [[lein-environ "1.0.2"]
             [lein-cljsbuild "1.1.5"]

--- a/src/clj/foosball_score/server.clj
+++ b/src/clj/foosball_score/server.clj
@@ -9,11 +9,22 @@
     [foosball-score.state :as state]
     [foosball-score.tcp :as tcp]
     [foosball-score.tick :as tick]
+    [foosball-score.slack :as slack]
     [foosball-score.statistics :as statistics]
     [foosball-score.persistence :as persist]
     [config.core :refer [env]]
     [org.httpkit.server :refer [run-server]])
   (:gen-class :main true))
+
+;;;;;;;;;;;;;;;;;
+;; Slack handling
+;;;;;;;;;;;;;;;;;
+(let [{:keys [post-msg!]} (slack/build-client (env :slack))]
+  (def post-slack-msg! post-msg!))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Foosball event responses
+;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defmethod foosball-event :default
   [event _]

--- a/src/clj/foosball_score/server.clj
+++ b/src/clj/foosball_score/server.clj
@@ -57,6 +57,8 @@
                            (persist-using! :winners persist/win-for!)
                            (persist-using! :losers persist/loss-for!)
                            (persist-using! :tiers persist/tie-for!))]
+        (if (state/game-over? next-state)
+          (post-slack-msg! (slack/game-outcome next-state)))
         (push-event! (delta state next-state))
         (state/update-state! next-state)))))
 

--- a/src/clj/foosball_score/slack.clj
+++ b/src/clj/foosball_score/slack.clj
@@ -21,10 +21,10 @@
   "Build a Slack incoming webhooks client that interfaces with the provided URL.
   Returns a map with the following functions identified by keyword:
   
-  - :post-msg! => accepts msg, a simple text message."
+  - :post-msg! => accepts msg, a simple text message"
   [url]
   (if (nil? url)
-    {:post-msg! (fn [_] (println "Attempt to call slack/post-msg! with a nil URL"))}
+    {:post-msg! (fn [msg] (println "\n---\nSlack (nil URL): " msg "\n---\n"))}
     {:post-msg! (partial post-msg! url)}))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/clj/foosball_score/slack.clj
+++ b/src/clj/foosball_score/slack.clj
@@ -1,0 +1,40 @@
+(ns foosball-score.slack
+  "Slack incoming webhook handler creation.
+  
+  Using the public interface to create a family of functions for interfacing with the Foosball Slack channel."
+  {:author "Ian McIntyre"}
+  (:require
+    [clj-http.client :as client]
+    [clojure.data.json :as json]
+    [foosball-score.state :as state]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Incoming webhooks interface
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn- post-msg!
+  "Send a simple text message to Slack"
+  [url msg]
+  (client/post url {:body (json/write-str {:text msg})} :content-type :json))
+
+(defn build-client
+  "Build a Slack incoming webhooks client that interfaces with the provided URL.
+  Returns a map with the following functions identified by keyword:
+  
+  - :post-msg! => accepts msg, a simple text message."
+  [url]
+  (if (nil? url)
+    {:post-msg! (fn [_] (println "Attempt to call slack/post-msg! with a nil URL"))}
+    {:post-msg! (partial post-msg! url)}))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Helpers for message formatting
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn game-outcome
+  "Create a message that describes the game outcome"
+  [{:keys [scores] :as state}]
+  (case (state/who-is-winning state)
+    :black (str "Black beat gold " (:black scores) " to " (:gold scores))
+    :gold  (str "Gold beat black " (:gold scores) " to " (:black scores))
+    nil    (str "Game was tied at " (:gold scores))))


### PR DESCRIPTION
The PR adds basic game reporting to the Foosball scoreboard. The end-game summary is posted to Slack. See the README for configuration.