### PR TITLE
Multiball games, pause the game

### DIFF
--- a/src/clj/foosball_score/events.clj
+++ b/src/clj/foosball_score/events.clj
@@ -12,8 +12,8 @@
 (def ^:private debug-callback! (atom (fn [_] nil)))
 
 (def event-lookup
-  { "BD" :drop        ; black drop - not specified as a unique event
-    "GD" :drop        ; gold drop - not specified as a unique event
+  { "BD" :black-drop  ; black drop
+    "GD" :gold-drop   ; gold drop
     "BG" :black       ; black goal
     "GG" :gold })     ; gold goal
 

--- a/src/cljc/foosball_score/state.cljc
+++ b/src/cljc/foosball_score/state.cljc
@@ -277,6 +277,12 @@
   {:pre [(some #{direction} [inc dec])]}
   (update-in state [:scores :max-score] (max-score-limiter direction)))
 
+(defn update-max-ball
+  "Update the maximum ball count"
+  [state direction]
+  {:pre [(some #{direction} [inc dec])]}
+  (update state :max-balls (ball-count-limiter direction)))
+
 (defn- update-end-time
   "Updates the end time"
   [state direction]

--- a/src/cljc/foosball_score/util.cljc
+++ b/src/cljc/foosball_score/util.cljc
@@ -5,6 +5,10 @@
 (def teams
   [:gold :black])
 
+(def opposites
+  {:black :gold
+   :gold :black})
+
 (defmacro const
   "Closure that captures x and returns it for any input argument."
   [x]

--- a/src/cljs/foosball_score/click.cljs
+++ b/src/cljs/foosball_score/click.cljs
@@ -21,6 +21,11 @@
   [state]
   (keypress-handler state \j))
 
+(defn play-pause
+  "Press to play or pause the game"
+  [state]
+  (keypress-handler state \p))
+
 (defn new-game
   "Start a new game"
   [state]

--- a/src/cljs/foosball_score/core.cljs
+++ b/src/cljs/foosball_score/core.cljs
@@ -98,7 +98,7 @@
          :on-key-press (partial on-key-press! state)}
    [modes/game-modes state (mode-click-handlers state)]
    [clock/game-clock state #(notify-server (click/new-game state))]
-   [game/scoreboard (game/state-depends state) :black :gold]
+   [game/scoreboard (game/state-depends state) :black :gold #(notify-server (click/play-pause state))]
    [status/status-msg state]
    [:div.scoreboard.debug {:on-click #(reset! debug-msg "")} @debug-msg]
    [players/player-list (players/state-depends state) (swap-team! state)]])

--- a/src/cljs/foosball_score/game.cljs
+++ b/src/cljs/foosball_score/game.cljs
@@ -53,18 +53,18 @@
 
 (defn scoreboard-content
   "A team's scoreboard content"
-  [state team align]
+  [state team align on-click]
   (let [color (team (get-colors state))
         scores (:scores state)]
-    [:div.scorecard {:class (scorecard-class state team) :style {:visibility (hidden-element state team)}}
+    [:div.scorecard {:on-click on-click :class (scorecard-class state team) :style {:visibility (hidden-element state team)}}
       [:h6 {:style {:color color :text-align align :visibility (hidden-element state team)}}
            (string/upper-case (name team))]
       [:h1 {:style {:color color :text-align align} :visibility (hidden-element state team)} (team scores)]]))
 
 (defn scoreboard
   "Create the game's scoreboard"
-  [state left right]
+  [state left right on-click]
   [:div.scoreboard
-    [scoreboard-content state left :right]
+    [scoreboard-content state left :right on-click]
     [score-time-list (:score-times state)]
-    [scoreboard-content state right :left]])
+    [scoreboard-content state right :left on-click]])

--- a/src/cljs/foosball_score/game.cljs
+++ b/src/cljs/foosball_score/game.cljs
@@ -14,7 +14,8 @@
 (defn state-depends
   "Describes the filtering of the state specific for this component"
   [state]
-  (select-keys state [:scores :game-mode :score-times :time :end-time]))
+  state
+  #_(select-keys state [:scores :game-mode :score-times :time :end-time]))
 
 (defn- scorecard-class
   "Change the scorecards class"
@@ -40,15 +41,25 @@
               color (team colors)]
           ^{:key (str time team color)} [:div {:style {:color color}} time]))]))
 
+(defn- hidden-element
+  "Returns :none if the element should be hidden, else nil"
+  [{:keys [game-mode status last-drop-team balls]} team]
+  (if (and (= :waiting status)
+           (= :multiball game-mode)
+           (> balls 0)
+           (= team last-drop-team))
+    :hidden
+    nil))
+
 (defn scoreboard-content
   "A team's scoreboard content"
   [state team align]
   (let [color (team (get-colors state))
         scores (:scores state)]
-    [:div.scorecard {:class (scorecard-class state team)}
-      [:h6 {:style {:color color :text-align align}}
+    [:div.scorecard {:class (scorecard-class state team) :style {:visibility (hidden-element state team)}}
+      [:h6 {:style {:color color :text-align align :visibility (hidden-element state team)}}
            (string/upper-case (name team))]
-      [:h1 {:style {:color color :text-align align}} (team scores)]]))
+      [:h1 {:style {:color color :text-align align} :visibility (hidden-element state team)} (team scores)]]))
 
 (defn scoreboard
   "Create the game's scoreboard"

--- a/src/cljs/foosball_score/keypress.cljs
+++ b/src/cljs/foosball_score/keypress.cljs
@@ -25,6 +25,10 @@
   [state direction]
   (state/update-max-score state direction))
 
+(defmethod handle-up-down :multiball
+  [state direction]
+  (state/update-max-ball state direction))
+
 (defmethod handle-up-down :timed
   [state direction]
   (let [lookup {inc state/increment-end-time

--- a/src/cljs/foosball_score/keypress.cljs
+++ b/src/cljs/foosball_score/keypress.cljs
@@ -17,6 +17,10 @@
   [state _]
   (state/swap-players state :gold))
 
+(defmethod keypress-handler \p
+  [state _]
+  (state/play-pause state))
+
 (defmulti handle-up-down
   "Update the state in the provided direction"
   (fn [{:keys [game-mode]} direction] game-mode))

--- a/src/cljs/foosball_score/status.cljs
+++ b/src/cljs/foosball_score/status.cljs
@@ -5,6 +5,7 @@
   (:require
     [foosball-score.state :as state]
     [foosball-score.colors :refer [get-colors]]
+    [foosball-score.util :refer [opposites]]
     [clojure.string :as string]))
 
 ;; --------------------------------
@@ -50,18 +51,22 @@
     (str "GAME OVER: " (get lookup winner))))
 
 (defn- get-status
-  "Get the current status message"
-  [{:keys [status] :as state}]
-  (cond
+  [{:keys [status last-drop-team balls] :as state}]
+  (string/upper-case (cond
     (state/game-over? state) (game-over-msg (state/who-is-winning state))
-    (state/overtime? state) "OVERTIME: NEXT GOAL WINS"
+    (state/overtime? state) "overtime: next goal wins"
+    (and (> balls 0)
+         (= :waiting status)
+         last-drop-team)
+      (let [opposite-team (opposites last-drop-team)]
+        (str (name opposite-team) " drops the next ball"))
     :else (let [msg-fn (status status-messages)]
-            (string/upper-case (msg-fn status)))))
+            (msg-fn status)))))
 
 (defn- status-style
-  "Get the corresponding status style"
   [{:keys [status] :as state}]
-  (if (or (state/game-over? state) (state/overtime? state))
+  (if (or (state/game-over? state)
+          (state/overtime? state))
     (hash-map :color ((get-colors state) (state/who-is-winning state)))
     (hash-map :color (status (get-colors state)))))
 

--- a/src/cljs/foosball_score/status.cljs
+++ b/src/cljs/foosball_score/status.cljs
@@ -51,7 +51,7 @@
     (str "GAME OVER: " (get lookup winner))))
 
 (defn- get-status
-  [{:keys [status last-drop-team balls] :as state}]
+  [{:keys [status last-drop-team balls max-balls] :as state}]
   (string/upper-case (cond
     (state/game-over? state) (game-over-msg (state/who-is-winning state))
     (state/overtime? state) "overtime: next goal wins"
@@ -59,7 +59,7 @@
          (= :waiting status)
          last-drop-team)
       (let [opposite-team (opposites last-drop-team)]
-        (str (name opposite-team) " drops the next ball"))
+        (str (name opposite-team) " drops the next ball (" (- max-balls balls) " left)"))
     :else (let [msg-fn (status status-messages)]
             (msg-fn status)))))
 

--- a/test/foosball_score/state_test.clj
+++ b/test/foosball_score/state_test.clj
@@ -318,3 +318,53 @@
   (testing "Increments end-time indefinitely by multiples of 15"
     (let [actual (nth (iterate state/increment-end-time {:end-time 30}) 100)]
       (is (= {:end-time 1530} actual)))))
+
+(deftest multiball-game
+  (testing "Two ball drops do not start game when three are needed"
+    (let [state (-> state/new-state
+                    (assoc :max-balls 3)
+                    (assoc :game-mode :multiball))
+          expected (-> state
+                       (assoc :balls 2))
+          actual (nth (iterate #(state/event->state % :drop) state) 2)]
+      (is (= expected actual))))
+      
+  (testing "Three ball drops transition into playing"
+    (let [state (-> state/new-state
+                    (assoc :max-balls 3)
+                    (assoc :game-mode :multiball))
+          expected (-> state
+                       (assoc :balls 3)
+                       (assoc :status :playing))
+          actual (nth (iterate #(state/event->state % :drop) state) 3)]
+      (is (= expected actual))))
+
+  (testing "Goal decrements ball count but not status"
+    (let [state (-> state/new-state
+                    (assoc :max-balls 3)
+                    (assoc :game-mode :multiball)
+                    (assoc :balls 3)
+                    (assoc :status :playing))
+          actual (state/event->state state :black)]
+      (is (= :playing (:status actual)))
+      (is (= 2 (:balls actual)))))
+      
+  (testing "Final goal chooses the last person who scored"
+    (let [state (-> state/new-state
+                    (assoc :max-balls 3)
+                    (assoc :game-mode :multiball)
+                    (assoc :balls 1)
+                    (assoc :status :playing))
+          actual (state/event->state state :black)]
+      (is (= :black (:status actual)))
+      (is (= 0 (:balls actual)))))
+      
+  (testing "Game is over when score sum is the number of balls"
+    (let [state (-> state/new-state
+                    (assoc :max-balls 3)
+                    (assoc :balls 0)
+                    (assoc :game-mode :multiball)
+                    (update-in [:scores :black] inc)
+                    (assoc-in [:scores :gold] 2))]
+      (is (state/game-over? state))
+      (is (not (state/game-over? (update-in state [:scores :gold] dec)))))))

--- a/test/foosball_score/state_test.clj
+++ b/test/foosball_score/state_test.clj
@@ -180,12 +180,12 @@
 (deftest event-state-transition-test
   (testing "Drop ball transitions to playing"
     (let [expected (assoc state/new-state :status :playing)]
-      (is (= expected (state/event->state state/new-state :drop)))))
+      (is (= expected (state/event->state state/new-state :gold-drop)))))
 
   (testing "Double-drop does nothing and returns nil for no update"
     (let [actual (-> state/new-state
-                     (state/event->state :drop)
-                     (state/event->state :drop))]
+                     (state/event->state :gold-drop)
+                     (state/event->state :black-drop))]
       (is (nil? actual))))
 
   (testing "No goals when not in playing state"
@@ -218,7 +218,7 @@
       (is (= expected (state/event->state input :tick)))))
 
   (testing "Time does not increment for any other status"
-    (doseq [status [:waiting :drop :black :gold]]
+    (doseq [status [:waiting :gold-drop :black-drop :black :gold]]
       (let [input (assoc state/new-state :status status)]
         (is (nil? (state/event->state input :tick))))))
 
@@ -237,7 +237,7 @@
 
   (testing "Game over state has no update"
     (is (nil? (state/event->state
-                (assoc-in state/new-state [:scores :black] 5) :drop))))
+                (assoc-in state/new-state [:scores :black] 5) :black-drop))))
 
   (testing "Game increments overtime counter when in overtime"
     (let [state (-> state/new-state
@@ -325,46 +325,51 @@
                     (assoc :max-balls 3)
                     (assoc :game-mode :multiball))
           expected (-> state
-                       (assoc :balls 2))
-          actual (nth (iterate #(state/event->state % :drop) state) 2)]
+                       (assoc :balls 2)
+                       (assoc :last-drop-team :black))
+          actual (-> state
+                     (state/event->state :gold-drop)
+                     (state/event->state :black-drop))]
       (is (= expected actual))))
       
-  (testing "Three ball drops transition into playing"
-    (let [state (-> state/new-state
-                    (assoc :max-balls 3)
-                    (assoc :game-mode :multiball))
-          expected (-> state
-                       (assoc :balls 3)
-                       (assoc :status :playing))
-          actual (nth (iterate #(state/event->state % :drop) state) 3)]
-      (is (= expected actual))))
+  ; (testing "Three ball drops transition into playing"
+  ;   (let [state (-> state/new-state
+  ;                   (assoc :max-balls 3)
+  ;                   (assoc :game-mode :multiball))
+  ;         expected (-> state
+  ;                      (assoc :balls 3)
+  ;                      (assoc :status :playing))
+  ;         actual (nth (iterate #(state/event->state % :drop) state) 3)]
+  ;     (is (= expected actual))))
 
-  (testing "Goal decrements ball count but not status"
-    (let [state (-> state/new-state
-                    (assoc :max-balls 3)
-                    (assoc :game-mode :multiball)
-                    (assoc :balls 3)
-                    (assoc :status :playing))
-          actual (state/event->state state :black)]
-      (is (= :playing (:status actual)))
-      (is (= 2 (:balls actual)))))
+  ; (testing "Goal decrements ball count but not status"
+  ;   (let [state (-> state/new-state
+  ;                   (assoc :max-balls 3)
+  ;                   (assoc :game-mode :multiball)
+  ;                   (assoc :balls 3)
+  ;                   (assoc :status :playing))
+  ;         actual (state/event->state state :black)]
+  ;     (is (= :playing (:status actual)))
+  ;     (is (= 2 (:balls actual)))))
       
-  (testing "Final goal chooses the last person who scored"
-    (let [state (-> state/new-state
-                    (assoc :max-balls 3)
-                    (assoc :game-mode :multiball)
-                    (assoc :balls 1)
-                    (assoc :status :playing))
-          actual (state/event->state state :black)]
-      (is (= :black (:status actual)))
-      (is (= 0 (:balls actual)))))
+  ; (testing "Final goal chooses the last person who scored"
+  ;   (let [state (-> state/new-state
+  ;                   (assoc :max-balls 3)
+  ;                   (assoc :game-mode :multiball)
+  ;                   (assoc :balls 1)
+  ;                   (assoc :status :playing))
+  ;         actual (state/event->state state :black)]
+  ;     (is (= :black (:status actual)))
+  ;     (is (= 0 (:balls actual)))))
       
-  (testing "Game is over when score sum is the number of balls"
-    (let [state (-> state/new-state
-                    (assoc :max-balls 3)
-                    (assoc :balls 0)
-                    (assoc :game-mode :multiball)
-                    (update-in [:scores :black] inc)
-                    (assoc-in [:scores :gold] 2))]
-      (is (state/game-over? state))
-      (is (not (state/game-over? (update-in state [:scores :gold] dec)))))))
+  ; (testing "Game is over when score sum is the number of balls"
+  ;   (let [state (-> state/new-state
+  ;                   (assoc :max-balls 3)
+  ;                   (assoc :balls 0)
+  ;                   (assoc :game-mode :multiball)
+  ;                   (update-in [:scores :black] inc)
+  ;                   (assoc-in [:scores :gold] 2))]
+  ;     (is (state/game-over? state))
+  ;     (is (not (state/game-over? (update-in state [:scores :gold] dec))))))
+      
+  )

--- a/test/foosball_score/state_test.clj
+++ b/test/foosball_score/state_test.clj
@@ -332,44 +332,59 @@
                      (state/event->state :black-drop))]
       (is (= expected actual))))
       
-  ; (testing "Three ball drops transition into playing"
-  ;   (let [state (-> state/new-state
-  ;                   (assoc :max-balls 3)
-  ;                   (assoc :game-mode :multiball))
-  ;         expected (-> state
-  ;                      (assoc :balls 3)
-  ;                      (assoc :status :playing))
-  ;         actual (nth (iterate #(state/event->state % :drop) state) 3)]
-  ;     (is (= expected actual))))
+  (testing "Three ball drops transition into playing"
+    (let [state (-> state/new-state
+                    (assoc :max-balls 3)
+                    (assoc :game-mode :multiball))
+          expected (-> state
+                       (assoc :balls 3)
+                       (assoc :last-drop-team :gold)
+                       (assoc :status :playing))
+          actual (-> state
+                     (state/event->state :gold-drop)
+                     (state/event->state :black-drop)
+                     (state/event->state :gold-drop))]
+      (is (= expected actual))))
 
-  ; (testing "Goal decrements ball count but not status"
-  ;   (let [state (-> state/new-state
-  ;                   (assoc :max-balls 3)
-  ;                   (assoc :game-mode :multiball)
-  ;                   (assoc :balls 3)
-  ;                   (assoc :status :playing))
-  ;         actual (state/event->state state :black)]
-  ;     (is (= :playing (:status actual)))
-  ;     (is (= 2 (:balls actual)))))
+  (testing "Three ball that don't alternate don't start a game"
+    (let [state (-> state/new-state
+                    (assoc :max-balls 3)
+                    (assoc :game-mode :multiball))
+          expected (-> state
+                       (assoc :balls 2)
+                       (assoc :last-drop-team :black))
+          actual (-> state
+                     (state/event->state :gold-drop)
+                     (state/event->state :gold-drop)
+                     (state/event->state :black-drop))]
+      (is (= expected actual))))
+
+  (testing "Goal decrements ball count but not status"
+    (let [state (-> state/new-state
+                    (assoc :max-balls 3)
+                    (assoc :game-mode :multiball)
+                    (assoc :balls 3)
+                    (assoc :status :playing))
+          actual (state/event->state state :black)]
+      (is (= :playing (:status actual)))
+      (is (= 2 (:balls actual)))))
       
-  ; (testing "Final goal chooses the last person who scored"
-  ;   (let [state (-> state/new-state
-  ;                   (assoc :max-balls 3)
-  ;                   (assoc :game-mode :multiball)
-  ;                   (assoc :balls 1)
-  ;                   (assoc :status :playing))
-  ;         actual (state/event->state state :black)]
-  ;     (is (= :black (:status actual)))
-  ;     (is (= 0 (:balls actual)))))
+  (testing "Final goal chooses the last person who scored"
+    (let [state (-> state/new-state
+                    (assoc :max-balls 3)
+                    (assoc :game-mode :multiball)
+                    (assoc :balls 1)
+                    (assoc :status :playing))
+          actual (state/event->state state :black)]
+      (is (= :black (:status actual)))
+      (is (= 0 (:balls actual)))))
       
-  ; (testing "Game is over when score sum is the number of balls"
-  ;   (let [state (-> state/new-state
-  ;                   (assoc :max-balls 3)
-  ;                   (assoc :balls 0)
-  ;                   (assoc :game-mode :multiball)
-  ;                   (update-in [:scores :black] inc)
-  ;                   (assoc-in [:scores :gold] 2))]
-  ;     (is (state/game-over? state))
-  ;     (is (not (state/game-over? (update-in state [:scores :gold] dec))))))
-      
-  )
+  (testing "Game is over when score sum is the number of balls"
+    (let [state (-> state/new-state
+                    (assoc :max-balls 3)
+                    (assoc :balls 0)
+                    (assoc :game-mode :multiball)
+                    (update-in [:scores :black] inc)
+                    (assoc-in [:scores :gold] 2))]
+      (is (state/game-over? state))
+      (is (not (state/game-over? (update-in state [:scores :gold] dec)))))))


### PR DESCRIPTION
The PR adds two recently requested features:

- **Multiball game mode**. Multiball games allow you to drop _N_ number of balls. After the _N_ th ball is dropped, the game starts. The game is over when the final ball is scored (which could result in a tie). Teams alternate dropping balls, and the UI lets you know who drops the next ball.
- **Pause the game**. Click one of the scores on the scoreboard to pause the current game. To restart, press the scoreboard again, or just drop the ball.