### PR TITLE
Asynchronize the backend

### DIFF
--- a/env/dev/clj/foosball_score/repl.clj
+++ b/env/dev/clj/foosball_score/repl.clj
@@ -53,7 +53,7 @@
       (async/pipeline 1 filt-chan (filter (comp not (partial = :tick) first)) out-chan)
       (go-loop [state (<! filt-chan)] (emit-event! state) (recur (<! filt-chan)))
       (reset! event-chan
-              (make-event-handler! #(put! in-chan %) debug-event!))
+              (make-event-handler! in-chan debug-event!))
       (listen-for-ws)
       (call-every-ms #(every-second in-chan) 1000))
     (println (str "You can view the site at http://localhost:" port))))

--- a/env/dev/clj/foosball_score/repl.clj
+++ b/env/dev/clj/foosball_score/repl.clj
@@ -6,7 +6,7 @@
         foosball-score.tick
         [ring.middleware file-info file]
         [org.httpkit.server :refer [run-server]]
-        [clojure.core.async :refer [go chan >! close!]]))
+        [clojure.core.async :refer [go go-loop chan >! <! close! put!]]))
 
 (defonce server (atom nil))
 (defonce event-chan (atom nil))
@@ -48,10 +48,12 @@
                    {:port port
                     :auto-reload? true
                     :join? false}))
-    (reset! event-chan
-            (make-event-handler! #(emit-event! (event-state-handler %)) debug-event!))
-    (listen-for-ws)
-    (call-every-ms every-second 1000)
+    (let [[in-chan out-chan] (event-state-task!)]
+      (go-loop [state (<! out-chan)] (emit-event! state) (recur (<! out-chan)))
+      (reset! event-chan
+              (make-event-handler! #(put! in-chan %) debug-event!))
+      (listen-for-ws)
+      (call-every-ms #(every-second in-chan) 1000))
     (println (str "You can view the site at http://localhost:" port))))
 
 (defn stop-server []

--- a/env/dev/clj/foosball_score/repl.clj
+++ b/env/dev/clj/foosball_score/repl.clj
@@ -6,7 +6,7 @@
         foosball-score.tick
         [ring.middleware file-info file]
         [org.httpkit.server :refer [run-server]]
-        [clojure.core.async :refer [go go-loop chan >! <! close! put!]]))
+        [clojure.core.async :as async :refer [go go-loop chan >! <! close! put!]]))
 
 (defonce server (atom nil))
 (defonce event-chan (atom nil))
@@ -48,8 +48,10 @@
                    {:port port
                     :auto-reload? true
                     :join? false}))
-    (let [[in-chan out-chan] (event-state-task!)]
-      (go-loop [state (<! out-chan)] (emit-event! state) (recur (<! out-chan)))
+    (let [[in-chan out-chan] (event-state-task!)
+          filt-chan (chan)]
+      (async/pipeline 1 filt-chan (filter (comp not (partial = :tick) first)) out-chan)
+      (go-loop [state (<! filt-chan)] (emit-event! state) (recur (<! filt-chan)))
       (reset! event-chan
               (make-event-handler! #(put! in-chan %) debug-event!))
       (listen-for-ws)

--- a/src/clj/foosball_score/events.clj
+++ b/src/clj/foosball_score/events.clj
@@ -6,7 +6,7 @@
   multi-character messages."
   {:author "Ian McIntyre"}
   (:require
-    [clojure.core.async :refer [go go-loop chan <! >!]]
+    [clojure.core.async :refer [go go-loop chan put! <! >!]]
     [foosball-score.persistence :as persist]))
 
 (def ^:private debug-callback! (atom (fn [_] nil)))
@@ -46,12 +46,12 @@
   "Create an event handler, and returns a channel that will be awaited on
   for serial events. Accepts a callback, a function to receive translated
   events."
-  ([callback] (make-event-handler! callback (fn [_] nil)))
-  ([callback debug-cb]
+  ([c] (make-event-handler! c (fn [_] nil)))
+  ([c debug-cb]
   (reset! debug-callback! debug-cb)
   (let [msg-chan (chan)]
     (go-loop [msg (<! msg-chan)]
       (if-let [event (on-msg-size msg)]
-        (callback event))
+        (put! c event))
       (recur (<! msg-chan)))
     msg-chan)))

--- a/src/clj/foosball_score/server.clj
+++ b/src/clj/foosball_score/server.clj
@@ -53,6 +53,9 @@
     state))
 
 (defn- event-state-handler
+  "Pipe the current state and event through a variety of state-transforming functions. If
+  one of them every returns nil, the operation is aborted, and the return is nil. Otherwise,
+  the return is a new state."
   [state event]
   (some-> state
           (state/event->state event)
@@ -62,21 +65,27 @@
           (persist-using! :tiers persist/tie-for!)))
 
 (defn event-state-task!
+  "Spawns a task to process events that change the Foosball state. Events are pushed onto
+  a channel, and the event with a new state is pushed onto an output channel. The return
+  is a tuple of the input and output channels. The output channel pushes messages of
+  [event new-state]."
   []
   (let [in  (chan)
         out (chan)]
-    (go-loop [event   (<! in)
-              state @state/state]
+    (go-loop [event   (<! in)       ; Get event from the input channel, waiting if necessary...
+              state @state/state]   ; ...then immediately grab the current state, which may have changed
       (when-let [next-state (event-state-handler state event)]
-        (if (state/game-over? next-state) (post-slack-msg! (slack/game-outcome next-state)))
+        (if (state/game-over? next-state)
+            (post-slack-msg! (slack/game-outcome next-state)))
         (push-event! (delta state next-state))
         (state/update-state! next-state)
         (put! out [event next-state]))
-      (recur (<! in) @state/state))
+      (recur (<! in)              ; Get the event from the input channel, waiting if necessary...
+             @state/state))       ; ...then immediately grab the current state, which may have changed
     [in out]))
 
 (defn every-second
-  "Invoked every second to sync the time across clients"
+  "Invoked every second to sync the time across clients. Pushes an event on the provided channel."
   [event-chan]
   (put! event-chan :tick))
 

--- a/src/clj/foosball_score/server.clj
+++ b/src/clj/foosball_score/server.clj
@@ -106,7 +106,7 @@
     (let [[event-chan _] (event-state-task!)]      
       (add-subscriber
         (events/make-event-handler!
-          #(put! event-chan %) #(push-event! {:debug %})))
+          event-chan #(push-event! {:debug %})))
       (run-server app {:port port :join? false})
       (listen-for-ws)
       (tick/call-every-ms #(every-second event-chan) 1000))))

--- a/src/clj/foosball_score/server.clj
+++ b/src/clj/foosball_score/server.clj
@@ -76,7 +76,7 @@
               state @state/state]   ; ...then immediately grab the current state, which may have changed
       (when-let [next-state (event-state-handler state event)]
         (if (state/game-over? next-state)
-            (post-slack-msg! (slack/game-outcome next-state)))
+            (go (post-slack-msg! (slack/game-outcome next-state))))
         (push-event! (delta state next-state))
         (state/update-state! next-state)
         (put! out [event next-state]))

--- a/src/cljs/foosball_score/core.cljs
+++ b/src/cljs/foosball_score/core.cljs
@@ -98,7 +98,7 @@
          :on-key-press (partial on-key-press! state)}
    [modes/game-modes state (mode-click-handlers state)]
    [clock/game-clock state #(notify-server (click/new-game state))]
-   [game/scoreboard (game/state-depends state) :black :gold #(notify-server (click/play-pause state))]
+   [game/scoreboard state :black :gold #(notify-server (click/play-pause state))]
    [status/status-msg state]
    [:div.scoreboard.debug {:on-click #(reset! debug-msg "")} @debug-msg]
    [players/player-list (players/state-depends state) (swap-team! state)]])

--- a/src/cljs/foosball_score/game.cljs
+++ b/src/cljs/foosball_score/game.cljs
@@ -11,12 +11,6 @@
 ;; --------------------------------
 ;; Functions
 
-(defn state-depends
-  "Describes the filtering of the state specific for this component"
-  [state]
-  state
-  #_(select-keys state [:scores :game-mode :score-times :time :end-time]))
-
 (defn- scorecard-class
   "Change the scorecards class"
   [state team]
@@ -39,7 +33,7 @@
         (let [time (game-time-str (item :time))
               team (item :team)
               color (team colors)]
-          ^{:key (str time team color)} [:div {:style {:color color}} time]))]))
+          ^{:key (gensym (str time team color))} [:div {:style {:color color}} time]))]))
 
 (defn- hidden-element
   "Returns :none if the element should be hidden, else nil"


### PR DESCRIPTION
The PR refactors the backend event processing pipeline to be an async task rather than a function. We observed a discrepancy between what the Foosball server posted to Slack, and what it showed on the UI. This may have been because both the timer task and the event task called event-state-handler at nearly the same point in time.

By moving the event processing into its own task, and using channels for coordination, there is no way for two separate tasks to influence the state at the same time. Now, if the tick task pushed onto the channel before the event task, only one event would be handled before the other. The channels are used for implicit queuing
